### PR TITLE
fixes issue with setting new can vesc id

### DIFF
--- a/src/app/device/device.page.ts
+++ b/src/app/device/device.page.ts
@@ -216,14 +216,14 @@ export class DevicePage {
     this.bleService.startNotifications(AppSettings.RESCUE_SERVICE_UUID,
       AppSettings.RESCUE_CHARACTERISTIC_UUID_CONF, (value: DataView) => {
         const values = String.fromCharCode.apply(null, new Uint8Array(value.buffer)).split('=');
-        if (!String(values[0]).startsWith('vesc')) {
-          this.logger.debug('Received CONF: ' + values);
-          if(typeof this.rescueConf[values[0]] === "boolean") {
-            this.rescueConf[values[0]] = Boolean(JSON.parse(values[1]));
-          } else {
-            this.rescueConf[values[0]] = values[1];
-          }
+
+        this.logger.debug('Received CONF: ' + values);
+        if(typeof this.rescueConf[values[0]] === "boolean") {
+          this.rescueConf[values[0]] = Boolean(JSON.parse(values[1]));
+        } else {
+          this.rescueConf[values[0]] = values[1];
         }
+
         if(String(values[0]).startsWith('sendConfigFinished')) {
           this.events.publishApplicationEvent({sendConfigFinished: true});
         }

--- a/src/app/settings/canbus/canbus.component.html
+++ b/src/app/settings/canbus/canbus.component.html
@@ -5,7 +5,7 @@
 </ion-item>
 <ion-item>
   <ion-input label="VESC-ID" class="ion-text-right" labelPlacement="stacked" 
-             type="number" min="1" [(ngModel)]="rescueConf.vescId"></ion-input>
+             type="number" min="1" [(ngModel)]="rescueConf.vescId" (ionChange)="changeVescId($event)"></ion-input>
 </ion-item>
 <ion-item-divider>
   <ion-label>

--- a/src/app/settings/canbus/canbus.component.ts
+++ b/src/app/settings/canbus/canbus.component.ts
@@ -13,6 +13,10 @@ export class CanbusComponent implements OnInit {
 
   ngOnInit() {}
 
+  changeVescId(event) {
+    this.rescueConf.vescId = event.detail.vescId;
+  }
+
   changeRealtimeDataInterval(event) {
     this.rescueConf.realtimeDataInterval = event.detail.value;
   }


### PR DESCRIPTION
1) fixes issue that vesc id was not readout from rESCue cause everything started with "vesc" was filtered
=> don't know why this was there, please double check for side effects i am not aware

2) fixes that changes in gui updates the vesc_id in the config

3) with this fixes the new vesc id gets set when you click "save and reboot"
however current rescue firmware does not apply it (it does not reboot)
=> you still have to reboot/restart rESCue yourself so that the new vesc can id gets applied

Added branch to add reboot function so it does reboot and apply the new vesc can id immediate
https://github.com/thankthemaker/rESCue/pull/93